### PR TITLE
Don't use iterators for `FlatMap` equality checks

### DIFF
--- a/src/flat_map/include/sourcemeta/noa/flat_map.h
+++ b/src/flat_map/include/sourcemeta/noa/flat_map.h
@@ -276,10 +276,10 @@ public:
     }
 
     for (const auto &entry : this->data) {
-      const auto iterator{other.find(entry.first, entry.hash)};
-      if (iterator == other.cend()) {
+      const auto *result{other.try_at(entry.first, entry.hash)};
+      if (!result) {
         return false;
-      } else if (iterator->second != entry.second) {
+      } else if (*result != entry.second) {
         return false;
       }
     }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
